### PR TITLE
Added docker compose and .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+bun 1.1.42
 java 21.0.5-tem
 nodejs 22.11.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+java 21.0.5-tem
+nodejs 22.11.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  timescaledb:
+    # Using the TimescaleDB HA (High Availability) version is required to enable the use of Timescale extensions.
+    image: timescale/timescaledb-ha:pg17
+    container_name: timescaled
+    environment:
+      - POSTGRES_PASSWORD=tst_eventify
+      - POSTGRES_USER=tst_eventify
+      - POSTGRES_DB=tst_eventify
+    ports:
+      - "5432:5432"
+    restart: always
+
+  inbucket:
+    image: inbucket/inbucket:latest
+    container_name: inbucket
+    ports:
+      - "9000:9000"  # Web UI port.
+      - "2500:2500"  # SMTP service port (correct port mapping).
+      - "1100:1100"  # POP3 service port.
+    restart: always

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -84,7 +84,6 @@ dependencies {
     implementation("org.springframework.boot", "spring-boot-starter-mail")
     implementation("org.springframework.boot", "spring-boot-starter-security")
     implementation("org.springframework.boot", "spring-boot-starter-oauth2-resource-server")
-    implementation(group = "org.springframework.boot", name = "spring-boot-starter-data-redis")
 
     implementation("org.springframework.boot", "spring-boot-starter-jdbc") {
         exclude("org.apache.tomcat", module = "tomcat-jdbc")

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -65,7 +65,7 @@ spring:
       maximumPoolSize: 20
       poolName: eventify
       registerMbeans: true
-    url: ${DATASOURCE_TOP_URL:jdbc:postgresql://100.89.27.58:5432/tst_eventify}
+    url: ${DATASOURCE_TOP_URL:jdbc:postgresql://localhost:5432/tst_eventify}
     username: ${DATASOURCE_TOP_USERNAME:tst_eventify}
     password: ${DATASOURCE_TOP_PASSWORD:tst_eventify}
     driverClassName: org.postgresql.Driver


### PR DESCRIPTION
- Added docker compose for `timescaledb` and `inbucket` (can be used later for the SMTP).
- Also added .tool-versions used within ASDF.
- Removed unused redis dependency.